### PR TITLE
ログイン画面およびユーザ新規登録画面の追加実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "next": "13.4.13",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-hook-form": "^7.45.4",
+        "react-icons": "^4.10.1",
         "typescript": "5.1.6"
       }
     },
@@ -4360,6 +4362,29 @@
         }
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.45.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.4.tgz",
+      "integrity": "sha512-HGDV1JOOBPZj10LB3+OZgfDBTn+IeEsNOKiq/cxbQAIbKaiJUe/KV8DBUzsx0Gx/7IG/orWqRRm736JwOfUSWQ==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
+      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8264,6 +8289,18 @@
         "use-callback-ref": "^1.3.0",
         "use-sidecar": "^1.1.2"
       }
+    },
+    "react-hook-form": {
+      "version": "7.45.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.4.tgz",
+      "integrity": "sha512-HGDV1JOOBPZj10LB3+OZgfDBTn+IeEsNOKiq/cxbQAIbKaiJUe/KV8DBUzsx0Gx/7IG/orWqRRm736JwOfUSWQ==",
+      "requires": {}
+    },
+    "react-icons": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
+      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "next": "13.4.13",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.45.4",
+    "react-icons": "^4.10.1",
     "typescript": "5.1.6"
   }
 }

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,9 +1,0 @@
-'use client'
-
-/** 新規・ログイン画面
- * @screenname AuthScreen
- * @description ユーザの新規登録・ログインを行う画面
- */
-export default function AuthScreen() {
-  return
-}

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,0 +1,134 @@
+'use client'
+import NextLink from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { FcGoogle } from 'react-icons/fc'
+
+import {
+  Box,
+  Button,
+  Flex,
+  FormLabel,
+  Heading,
+  Icon,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Text,
+  useToast,
+  VStack,
+} from '@/common/design'
+import { validateSignInScreen } from '@/common/utils/validate'
+import Loading from '@/components/loading.component'
+
+/** サインイン画面
+ * @screenname SignInScreen
+ * @description ユーザのサインインを行う画面
+ */
+export default function SignInScreen() {
+  const toast = useToast()
+  const router = useRouter()
+  const { handleSubmit, register } = useForm()
+  const [show, setShow] = useState<boolean>(false)
+  const [loading, setLoading] = useState<boolean>(false)
+
+  const googleClick = () => {
+    router.push('/home')
+  }
+
+  const onSubmit = handleSubmit(async (data) => {
+    setLoading(true)
+    // バリデーションチェック
+    const error = validateSignInScreen(data.email, data.password)
+    if (error.isSuccess) {
+      toast({
+        title: 'ログインに成功しました',
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
+      })
+    } else {
+      // バリデーションエラー
+      toast({
+        title: error.message,
+        status: 'error',
+        duration: 2000,
+        isClosable: true,
+      })
+    }
+  })
+  return loading ? (
+    <Loading />
+  ) : (
+    <Flex
+      flexDirection='column'
+      width='100%'
+      height='100vh'
+      justifyContent='center'
+      alignItems='center'
+    >
+      <VStack spacing='5'>
+        <Heading>ログイン</Heading>
+        <form onSubmit={onSubmit}>
+          <VStack spacing='4' alignItems='left'>
+            <Box>
+              <FormLabel htmlFor='email' textAlign='start'>
+                メールアドレス
+              </FormLabel>
+              <Input id='email' {...register('email')} />
+            </Box>
+
+            <Box>
+              <FormLabel htmlFor='password'>パスワード</FormLabel>
+              <InputGroup size='md'>
+                <Input
+                  pr='4.5rem'
+                  type={show ? 'text' : 'password'}
+                  {...register('password')}
+                />
+                <InputRightElement width='4.5rem'>
+                  <Button h='1.75rem' size='sm' onClick={() => setShow(!show)}>
+                    {show ? 'Hide' : 'Show'}
+                  </Button>
+                </InputRightElement>
+              </InputGroup>
+            </Box>
+            <Button
+              marginTop='4'
+              colorScheme='teal'
+              type='submit'
+              paddingX='auto'
+            >
+              ログイン
+            </Button>
+            <Flex
+              flexDirection='column'
+              width='100%'
+              justifyContent='center'
+              alignItems='center'
+            >
+              <Icon
+                as={FcGoogle}
+                marginTop='20px'
+                width='6'
+                height='6'
+                cursor='pointer'
+                onClick={() => googleClick()}
+              />
+              <Button
+                as={NextLink}
+                href='/signup'
+                bg='white'
+                width='100%'
+                marginTop='20px'
+              >
+                新規登録はこちらから
+              </Button>
+            </Flex>
+          </VStack>
+        </form>
+      </VStack>
+    </Flex>
+  )
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -18,6 +18,10 @@ import {
 } from '@/common/design'
 import { validateSignUpScreen } from '@/common/utils/validate'
 
+/** サインアップ画面
+ * @screenname SignUpScreen
+ * @description ユーザの新規登録を行う画面
+ */
 export default function SignUpScreen() {
   const router = useRouter()
   const toast = useToast()

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,128 @@
+'use client'
+import NextLink from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import {
+  Box,
+  Button,
+  Flex,
+  FormLabel,
+  Heading,
+  Input,
+  InputGroup,
+  InputRightElement,
+  useToast,
+  VStack,
+} from '@/common/design'
+import { validateSignUpScreen } from '@/common/utils/validate'
+
+export default function SignUpScreen() {
+  const router = useRouter()
+  const toast = useToast()
+  const { handleSubmit, register } = useForm()
+
+  const [password, setPassword] = useState(false)
+  const [confirm, setConfirm] = useState(false)
+
+  const onSubmit = handleSubmit((data) => {
+    // バリデーションチェック
+    const error = validateSignUpScreen({
+      username: data.username,
+      email: data.email,
+      password: data.password,
+      confirmPassword: data.confirm,
+    })
+    if (error.isSuccess) {
+      router.push('/signin')
+    } else {
+      // バリデーションエラー
+      toast({
+        title: error.message,
+        status: 'error',
+        duration: 2000,
+        isClosable: true,
+      })
+    }
+  })
+
+  const passwordClick = () => setPassword(!password)
+  const confirmClick = () => setConfirm(!confirm)
+
+  const googleClick = async () => {}
+
+  return (
+    <Flex height='100vh' justifyContent='center' alignItems='center'>
+      <VStack spacing='5'>
+        <Heading>新規登録</Heading>
+        <form onSubmit={onSubmit}>
+          <VStack alignItems='left'>
+            <Box>
+              <FormLabel htmlFor='username' textAlign='start'>
+                ユーザ名
+              </FormLabel>
+              <Input id='username' {...register('username')} />
+            </Box>
+            <Box>
+              <FormLabel htmlFor='email' textAlign='start'>
+                メールアドレス
+              </FormLabel>
+              <Input id='email' {...register('email')} />
+            </Box>
+
+            <Box>
+              <FormLabel htmlFor='password'>パスワード</FormLabel>
+              <InputGroup size='md'>
+                <Input
+                  pr='4.5rem'
+                  type={password ? 'text' : 'password'}
+                  {...register('password')}
+                />
+                <InputRightElement width='4.5rem'>
+                  <Button h='1.75rem' size='sm' onClick={passwordClick}>
+                    {password ? 'Hide' : 'Show'}
+                  </Button>
+                </InputRightElement>
+              </InputGroup>
+            </Box>
+
+            <Box>
+              <FormLabel htmlFor='confirm'>パスワード確認</FormLabel>
+              <InputGroup size='md'>
+                <Input
+                  pr='4.5rem'
+                  type={confirm ? 'text' : 'password'}
+                  {...register('confirm')}
+                />
+                <InputRightElement width='4.5rem'>
+                  <Button h='1.75rem' size='sm' onClick={confirmClick}>
+                    {confirm ? 'Hide' : 'Show'}
+                  </Button>
+                </InputRightElement>
+              </InputGroup>
+            </Box>
+
+            <Button
+              marginTop='4'
+              colorScheme='teal'
+              type='submit'
+              paddingX='auto'
+            >
+              新規登録
+            </Button>
+          </VStack>
+        </form>
+        <Button
+          as={NextLink}
+          href='/signin'
+          bg='white'
+          width='100%'
+          marginTop='20px'
+        >
+          ログインはこちらから
+        </Button>
+      </VStack>
+    </Flex>
+  )
+}

--- a/src/common/utils/validate.ts
+++ b/src/common/utils/validate.ts
@@ -1,0 +1,44 @@
+// バリデーションタイプ
+type Validate = {
+  isSuccess: boolean
+  message: string
+}
+
+// サインイン画面のバリデーション
+export const validateSignInScreen = (
+  email: string,
+  password: string
+): Validate => {
+  if (!email) {
+    return { isSuccess: false, message: 'メールアドレスを入力してください' }
+  }
+  if (!password) {
+    return { isSuccess: false, message: 'パスワードを入力してください' }
+  }
+  return { isSuccess: true, message: '' }
+}
+
+// サインアップ画面のバリデーション
+export const validateSignUpScreen = (args: {
+  username: string
+  email: string
+  password: string
+  confirmPassword: string
+}): Validate => {
+  if (!args.username) {
+    return { isSuccess: false, message: 'ユーザー名を入力してください' }
+  }
+  if (!args.email) {
+    return { isSuccess: false, message: 'メールアドレスを入力してください' }
+  }
+  if (!args.password) {
+    return { isSuccess: false, message: 'パスワードを入力してください' }
+  }
+  if (!args.confirmPassword) {
+    return { isSuccess: false, message: '確認用パスワードを入力してください' }
+  }
+  if (args.password !== args.confirmPassword) {
+    return { isSuccess: false, message: 'パスワードが一致しません' }
+  }
+  return { isSuccess: true, message: '' }
+}


### PR DESCRIPTION
closed #7 の対応
## 実装内容
- ログイン画面のレイアウトを実装
  - Google認証用ボタン
  - メール／パスワードの認証
  - 新規登録画面への遷移ボタン
- 新規登録画面の追加実装
  - 新規登録フォームの実装
  - ログイン画面への遷移ボタン

## その他対応
上記のフォームの入力チェック実装に伴い、`utils / validate.ts`ファイルを追加
以降の入力チェックなどはこのファイルに追加していく