### PR TITLE
プロフィール画面及びお問い合わせ画面の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "framer-motion": "^10.15.1",
         "next": "13.4.13",
         "react": "18.2.0",
+        "react-calendar-heatmap": "^1.9.0",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.45.4",
         "react-icons": "^4.10.1",
@@ -29,6 +30,7 @@
         "typescript": "5.1.6"
       },
       "devDependencies": {
+        "@types/react-calendar-heatmap": "^1.6.3",
         "encoding": "^0.1.13"
       }
     },
@@ -5496,6 +5498,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-calendar-heatmap": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@types/react-calendar-heatmap/-/react-calendar-heatmap-1.6.3.tgz",
+      "integrity": "sha512-C6hN9Nl0NBqeJEkivwwf/bvWNoPwpwGSNABwYl0yHD20rClSJqRgYoGPKDIn8QqoYHGJsTFJdFbBAZRPlJ/+qg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-dom": {
       "version": "18.2.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
@@ -10133,8 +10144,7 @@
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "peer": true
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/merge-options": {
       "version": "3.0.4",
@@ -11778,6 +11788,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar-heatmap": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/react-calendar-heatmap/-/react-calendar-heatmap-1.9.0.tgz",
+      "integrity": "sha512-mGed9any6QLOVckxwxC/eeP9s9wE8mTUW/FCE0V27xF9WOaCGuOftGSRH8DSDoSwgzMSVF6uuH7M1xvc+aZ8sg==",
+      "dependencies": {
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-clientside-effect": {
@@ -17980,6 +18002,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/react-calendar-heatmap": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@types/react-calendar-heatmap/-/react-calendar-heatmap-1.6.3.tgz",
+      "integrity": "sha512-C6hN9Nl0NBqeJEkivwwf/bvWNoPwpwGSNABwYl0yHD20rClSJqRgYoGPKDIn8QqoYHGJsTFJdFbBAZRPlJ/+qg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-dom": {
       "version": "18.2.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
@@ -21524,8 +21555,7 @@
     "memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "peer": true
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "merge-options": {
       "version": "3.0.4",
@@ -22747,6 +22777,15 @@
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "react-calendar-heatmap": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/react-calendar-heatmap/-/react-calendar-heatmap-1.9.0.tgz",
+      "integrity": "sha512-mGed9any6QLOVckxwxC/eeP9s9wE8mTUW/FCE0V27xF9WOaCGuOftGSRH8DSDoSwgzMSVF6uuH7M1xvc+aZ8sg==",
+      "requires": {
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.2"
       }
     },
     "react-clientside-effect": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "framer-motion": "^10.15.1",
     "next": "13.4.13",
     "react": "18.2.0",
+    "react-calendar-heatmap": "^1.9.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.4",
     "react-icons": "^4.10.1",
@@ -30,6 +31,7 @@
     "typescript": "5.1.6"
   },
   "devDependencies": {
+    "@types/react-calendar-heatmap": "^1.6.3",
     "encoding": "^0.1.13"
   }
 }

--- a/src/app/contact/post/page.tsx
+++ b/src/app/contact/post/page.tsx
@@ -1,9 +1,98 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+
+import {
+  Box,
+  Button,
+  Flex,
+  FormLabel,
+  Heading,
+  Input,
+  Textarea,
+  useToast,
+  VStack,
+} from '@/common/design'
+import { validateContactScreen } from '@/common/utils/validate'
+import { postContact } from '@/lib/firebase/api/contact'
+
 /** お問い合わせ送信画面
  * @screenname PostContactScreen
  * @description お問い合わせを送信する画面
  */
 export default function PostContactScreen() {
-  return
+  const router = useRouter()
+  const toast = useToast()
+  const { handleSubmit, register } = useForm()
+  const onSubmit = handleSubmit(async (data) => {
+    const result = validateContactScreen({
+      title: data.title,
+      content: data.content,
+    })
+
+    if (result.isSuccess) {
+      await postContact({ title: data.title, content: data.content }).then(
+        (res) => {
+          if (res.isSuccess) {
+            toast({
+              title: res.message,
+              status: 'success',
+              duration: 2000,
+              isClosable: true,
+            })
+            router.back()
+          } else {
+            toast({
+              title: res.message,
+              status: 'error',
+              duration: 2000,
+              isClosable: true,
+            })
+          }
+        }
+      )
+    } else {
+      // バリデーションエラー
+      toast({
+        title: result.message,
+        status: 'error',
+        duration: 2000,
+        isClosable: true,
+      })
+    }
+  })
+  return (
+    <Flex flexDirection='column' width='100%' gap='24px' paddingY='20px'>
+      <Heading fontSize='22px'>お問い合わせフォーム</Heading>
+      <form onSubmit={onSubmit}>
+        <VStack alignItems='left'>
+          <Box>
+            <FormLabel htmlFor='title' textAlign='start'>
+              タイトル
+            </FormLabel>
+            <Input id='title' {...register('title')} />
+          </Box>
+          <Box>
+            <FormLabel htmlFor='content' textAlign='start'>
+              お問い合わせ内容
+            </FormLabel>
+            <Textarea id='content' {...register('content')} />
+          </Box>
+
+          <Button
+            marginTop='4'
+            colorScheme='teal'
+            type='submit'
+            paddingX='auto'
+          >
+            送信
+          </Button>
+          <Button marginTop='4' paddingX='auto' onClick={() => router.back()}>
+            戻る
+          </Button>
+        </VStack>
+      </form>
+    </Flex>
+  )
 }

--- a/src/app/global.module.css
+++ b/src/app/global.module.css
@@ -5,3 +5,23 @@
 .body::-webkit-scrollbar {
   display: none;
 }
+
+.color_empty {
+  fill: #ffffff;
+}
+
+.color_scale_1 {
+  fill: #95F985;
+}
+
+.color_scale_2 {
+  fill: #4DED30;
+}
+
+.color_scale_3 {
+  fill: #26D701;
+}
+
+.color_scale_4 {
+  fill: #00AB08;
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -38,7 +38,10 @@ export default function HomeScreen() {
   const [examId, setExamId] = useState<string>('')
   useEffect(() => {
     const fetch = async () => {
-      await getAllCertifications().then((res) => setCertifications(res))
+      await getAllCertifications().then((res: Certification[]) => {
+        console.log(res[0].examType[0])
+        setCertifications(res)
+      })
     }
     fetch()
   }, [])

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,9 +1,63 @@
 'use client'
 
+import { useRecoilValue } from 'recoil'
+
+import {
+  Flex,
+  Heading,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Tr,
+} from '@/common/design'
+import { userState } from '@/common/states/user'
+import Calendar from '@/components/calendar.component'
+
 /** プロフィール画面
  * @screenname ProfileScreen
  * @description ユーザ情報を表示する画面
  */
 export default function ProfileScreen() {
-  return
+  const user = useRecoilValue(userState)
+  return (
+    <Flex flexDirection='column' width='100%' gap='18px' paddingY='20px'>
+      <Heading fontSize='22px'>プロフィール</Heading>
+      <Flex width='100%' flexDirection='row' alignContent='center' gap='20px'>
+        <Heading fontSize='18px'>ユーザ名：</Heading>
+        <Text fontSize='14px'>{user?.username}</Text>
+      </Flex>
+      <Flex
+        width={{ base: '100%', md: '70%' }}
+        justifyContent='center'
+        alignItems='center'
+        marginX={{ base: '0px', md: 'auto' }}
+      >
+        <Calendar articleList={[]} />
+      </Flex>
+      <TableContainer marginX='10px'>
+        <Table>
+          <Tbody>
+            <Tr>
+              <Td>正答数</Td>
+              <Td>20問</Td>
+            </Tr>
+            <Tr>
+              <Td>正答率</Td>
+              <Td>50%</Td>
+            </Tr>
+            <Tr>
+              <Td>誤答数</Td>
+              <Td>20問</Td>
+            </Tr>
+            <Tr>
+              <Td>回答数</Td>
+              <Td>40問</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </Flex>
+  )
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -76,8 +76,6 @@ export default function SignUpScreen() {
   const passwordClick = () => setPassword(!password)
   const confirmClick = () => setConfirm(!confirm)
 
-  const googleClick = async () => {}
-
   return (
     <Flex height='100vh' justifyContent='center' alignItems='center'>
       <VStack spacing='5'>

--- a/src/common/models/user.model.ts
+++ b/src/common/models/user.model.ts
@@ -2,4 +2,5 @@
 export type User = {
   uid: string
   username: string
+  email: string
 }

--- a/src/common/providers/auth_guard.tsx
+++ b/src/common/providers/auth_guard.tsx
@@ -28,6 +28,7 @@ export const AuthGuard = ({ children }: Props) => {
       toast({
         title: 'ログインしてください',
         status: 'error',
+        duration: 2000,
         isClosable: true,
       })
     }

--- a/src/common/utils/validate.ts
+++ b/src/common/utils/validate.ts
@@ -42,3 +42,17 @@ export const validateSignUpScreen = (args: {
   }
   return { isSuccess: true, message: '' }
 }
+
+// お問い合わせ画面のバリデーション
+export const validateContactScreen = (args: {
+  title: string
+  content: string
+}): Validate => {
+  if (!args.title) {
+    return { isSuccess: false, message: 'タイトルを入力してください' }
+  }
+  if (!args.content) {
+    return { isSuccess: false, message: '内容を入力してください' }
+  }
+  return { isSuccess: true, message: '' }
+}

--- a/src/components/calendar.component.tsx
+++ b/src/components/calendar.component.tsx
@@ -1,0 +1,73 @@
+'use client'
+import 'react-calendar-heatmap/dist/styles.css'
+
+import { useEffect, useState } from 'react'
+import CalendarHeatmap from 'react-calendar-heatmap'
+
+import styles from '@/app/global.module.css'
+
+type Props = {
+  articleList: any[]
+}
+
+export default function Calendar({ articleList }: Props) {
+  // 今日の日付を取得
+  const today = new Date()
+  // 三カ月前の日付を計算
+  const sixMonthAgo = new Date(
+    today.getFullYear(),
+    today.getMonth() - 6,
+    today.getDate()
+  )
+
+  // 投稿した日付の数をカウント
+  const countsByDate: Record<string, number> = {}
+  articleList.forEach(({ createdAt }) => {
+    if (!countsByDate[createdAt]) {
+      countsByDate[createdAt] = 0
+    }
+    countsByDate[createdAt] += 1
+  })
+  const [articles, setArticles] = useState<{ date: string; count: number }[]>(
+    []
+  )
+
+  useEffect(() => {
+    const data = articleList.map((e) => {
+      const date = e.createdAt
+      const count: number = countsByDate[date] || 0
+      return {
+        date,
+        count,
+      }
+    })
+    setArticles(data)
+  }, [])
+
+  return (
+    <CalendarHeatmap
+      startDate={sixMonthAgo}
+      endDate={today}
+      values={articles}
+      classForValue={(value) => {
+        if (!value) {
+          return styles.color_empty
+        }
+
+        // 投稿数に応じてカレンダーの色を変える
+        switch (value.count) {
+          case 1:
+            return styles.color_scale_1
+          case 2:
+            return styles.color_scale_2
+          case 3:
+            return styles.color_scale_3
+          default:
+            if (value.count >= 4) {
+              return styles.color_scale_4
+            }
+        }
+      }}
+    />
+  )
+}

--- a/src/components/footer.component.tsx
+++ b/src/components/footer.component.tsx
@@ -1,17 +1,22 @@
 'use client'
 import NextLink from 'next/link'
 
-import { Box, Button, Container, Flex, Heading, Text } from '@/common/design'
+import { Box, Container, Flex, HStack, Text } from '@/common/design'
 
 export default function Footer() {
   return (
     <Box bg='gray.50' color='gray.700' as='footer'>
       <Container maxW='4xl' py={4}>
         <Flex justify='space-between' align='center'>
-          <Text as='small'>© 2023 yappi</Text>
-          <Heading size='sm'>
-            <NextLink href='/contact'>お問い合わせ</NextLink>
-          </Heading>
+          <Text fontSize='12px'>© 2023 yappi</Text>
+          <HStack spacing={4}>
+            <NextLink href='/contact'>
+              <Text fontSize='12px'>お問い合わせ</Text>
+            </NextLink>
+            <NextLink href='/profile'>
+              <Text fontSize='12px'>プロフィール</Text>
+            </NextLink>
+          </HStack>
         </Flex>
       </Container>
     </Box>

--- a/src/components/header.component.tsx
+++ b/src/components/header.component.tsx
@@ -76,10 +76,28 @@ export default function Header() {
               gap='10px'
               paddingY='10px'
             >
-              <Button onClick={() => router.push('profile')}>
+              <Button
+                onClick={() => {
+                  router.push('/home')
+                  onClose()
+                }}
+              >
+                ホーム画面
+              </Button>
+              <Button
+                onClick={() => {
+                  router.push('/profile')
+                  onClose()
+                }}
+              >
                 プロフィール画面
               </Button>
-              <Button onClick={() => router.push('contact')}>
+              <Button
+                onClick={() => {
+                  router.push('/contact')
+                  onClose()
+                }}
+              >
                 お問い合わせ画面
               </Button>
               <Button

--- a/src/lib/firebase/api/auth.ts
+++ b/src/lib/firebase/api/auth.ts
@@ -88,12 +88,16 @@ export const signInWithGoogle = async (): Promise<FirebaseResult> => {
           updateDoc(docRef, {
             uid: userCredential.user.uid,
             username: userCredential.user.displayName,
+            email: userCredential.user.email,
+            loginAt: serverTimestamp(),
           })
         } else {
           await setDoc(docRef, {
             uid: userCredential.user.uid,
             username: userCredential.user.displayName,
+            email: userCredential.user.email,
             createdAt: serverTimestamp(),
+            loginAt: serverTimestamp(),
           })
         }
         return userCredential.user
@@ -130,7 +134,9 @@ export const signUpWithEmail = async (args: {
       await setDoc(docRef, {
         uid: userCredential.user.uid,
         username: args.username,
+        email: userCredential.user.email,
         createdAt: serverTimestamp(),
+        loginAt: serverTimestamp(),
       })
       return userCredential.user
     })

--- a/src/lib/firebase/api/certifications.ts
+++ b/src/lib/firebase/api/certifications.ts
@@ -1,6 +1,6 @@
 import { collection, getDocs, query, where } from 'firebase/firestore'
 
-import { Certification } from '@/common/models/certification.model'
+import { Certification, ExamType } from '@/common/models/certification.model'
 import { db } from '@/lib/config'
 
 /**
@@ -16,14 +16,8 @@ export const getAllCertifications = async () => {
       pltName: doc.data().pltName,
       pltPath: doc.data().pltPath,
       isActive: doc.data().isActive,
-      examType: doc.data().examType.map((examType: any) => {
-        return {
-          examTypeId: examType.examTypeId,
-          examTypeName: examType.examTypeName,
-          isActive: examType.isActive,
-        }
-      }),
-    }
+      examType: doc.data().examType,
+    } as Certification
   })
   return certifications
 }

--- a/src/lib/firebase/api/contact.ts
+++ b/src/lib/firebase/api/contact.ts
@@ -1,0 +1,42 @@
+import { addDoc, collection, doc, serverTimestamp } from 'firebase/firestore'
+
+import { FirebaseResult } from '@/common/models/firebase_result.model'
+import { auth, db } from '@/lib/config'
+
+import { getUserInfoByUid } from './users'
+
+export const postContact = async (args: {
+  title: string
+  content: string
+}): Promise<FirebaseResult> => {
+  let result: FirebaseResult = {
+    isSuccess: false,
+    message: '',
+  }
+  const user = auth.currentUser
+  const colRef = collection(db, 'contacts')
+  const userInfo = await getUserInfoByUid({ uid: user!.uid })
+  if (userInfo) {
+    await addDoc(colRef, {
+      contactTitle: args.title,
+      contactContent: args.content,
+      createdAt: serverTimestamp(),
+      contactFrom: {
+        uid: userInfo.uid,
+        username: userInfo.username,
+        email: userInfo.email,
+      },
+    }).then(() => {
+      result = {
+        isSuccess: true,
+        message: 'お問い合わせを送信しました。',
+      }
+    })
+  } else {
+    result = {
+      isSuccess: false,
+      message: 'ユーザ情報の取得に失敗しました。',
+    }
+  }
+  return result
+}

--- a/src/lib/firebase/api/users.ts
+++ b/src/lib/firebase/api/users.ts
@@ -10,7 +10,7 @@ import { db } from '@/lib/config'
 export const getUserInfoByUid = async (args: {
   uid: string
 }): Promise<User> => {
-  let result: User = { uid: '', username: '' }
+  let result: User = { uid: '', username: '', email: '' }
   try {
     const docRef = doc(db, 'users', args.uid)
     const docSnap = await getDoc(docRef)
@@ -18,6 +18,7 @@ export const getUserInfoByUid = async (args: {
       result = {
         uid: docSnap.data().uid,
         username: docSnap.data().username,
+        email: docSnap.data().email,
       }
     }
   } catch (error) {


### PR DESCRIPTION
closed #20 について
#21 について
## 実装内容
お問い合わせ画面の実装および、送信データをfirestoreに格納までの機能を実装
プロフィール画面のレイアウト、草カレンダーのパッケージインストール及び実装の完了
まだfirebaseからデータを取得して表示するまでには至っていないため、タスクとしては残しておく。