### PR TITLE
プロフィール更新画面の実装

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,9 +1,10 @@
 'use client'
-
+import NextLink from 'next/link'
 import { useEffect, useState } from 'react'
 import { useRecoilValue } from 'recoil'
 
 import {
+  Button,
   Flex,
   Heading,
   Table,
@@ -50,10 +51,21 @@ export default function ProfileScreen() {
     <Loading />
   ) : (
     <Flex flexDirection='column' width='100%' gap='18px' paddingY='5px'>
-      <Heading fontSize='22px'>プロフィール</Heading>
+      <Flex width='100%' flexDirection='row' justifyContent='space-between'>
+        <Heading fontSize='22px'>プロフィール</Heading>
+        <Button as={NextLink} href='/profile/update'>
+          更新
+        </Button>
+      </Flex>
       <Flex width='100%' flexDirection='row' alignItems='center' gap='20px'>
         <Heading fontSize='18px'>ユーザ名：</Heading>
         <Text fontSize='18px'>{user?.username}</Text>
+      </Flex>
+      <Flex width='100%' flexDirection='row' alignItems='center' gap='20px'>
+        <Heading fontSize='18px'>定期メール：</Heading>
+        <Text fontSize='18px'>
+          {user?.permSendEmail ? '受け取る' : '受け取らない'}
+        </Text>
       </Flex>
       <Flex
         width={{ base: '100%', sm: '100%', md: '100%', lg: '60%' }}

--- a/src/app/profile/update/page.tsx
+++ b/src/app/profile/update/page.tsx
@@ -1,0 +1,114 @@
+'use client'
+import NextLink from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useRecoilState } from 'recoil'
+
+import {
+  Box,
+  Button,
+  Flex,
+  FormLabel,
+  Heading,
+  Input,
+  Switch,
+  Text,
+  useToast,
+  VStack,
+} from '@/common/design'
+import { userState } from '@/common/states/user'
+import { validateUpdateProfileScreen } from '@/common/utils/validate'
+import { updateUserInfo } from '@/lib/firebase/api/users'
+
+/** プロフィール更新画面
+ * @screenname UpdateProfileScreen
+ * @description ユーザ情報を更新する画面
+ */
+export default function UpdateProfileScreen() {
+  const toast = useToast()
+  const router = useRouter()
+  const [user, setUser] = useRecoilState(userState)
+  const [check, setCheck] = useState<boolean>(user!.permSendEmail)
+  const { handleSubmit, register } = useForm()
+  const onSubmit = handleSubmit(async (data) => {
+    const result = validateUpdateProfileScreen(data.username)
+    if (result.isSuccess) {
+      await updateUserInfo({
+        username: data.username,
+        permSendEmail: check,
+      }).then((res) => {
+        if (res.isSuccess) {
+          setUser((prevState) => ({
+            ...prevState!,
+            username: data.username,
+            permSendEmail: check,
+          }))
+          router.replace('/profile')
+          toast({
+            title: res.message,
+            status: 'success',
+            duration: 2000,
+            isClosable: true,
+          })
+        } else {
+          toast({
+            title: res.message,
+            status: 'error',
+            duration: 2000,
+            isClosable: true,
+          })
+        }
+      })
+    } else {
+      // バリデーションエラー
+      toast({
+        title: result.message,
+        status: 'error',
+        duration: 2000,
+        isClosable: true,
+      })
+    }
+  })
+  return (
+    <Flex flexDirection='column' width='100%' gap='18px' paddingY='5px'>
+      <Flex width='100%' flexDirection='row' justifyContent='space-between'>
+        <Heading fontSize='22px'>プロフィール更新</Heading>
+        <Button as={NextLink} href='/profile'>
+          戻る
+        </Button>
+      </Flex>
+      <form onSubmit={onSubmit}>
+        <VStack spacing='4' alignItems='left'>
+          <Box>
+            <FormLabel htmlFor='username' textAlign='start'>
+              ユーザ名
+            </FormLabel>
+            <Input
+              defaultValue={user?.username}
+              id='username'
+              {...register('username')}
+            />
+          </Box>
+          <Box>
+            <FormLabel htmlFor='permSendEmail' textAlign='start'>
+              定期メールを受け取る
+            </FormLabel>
+            <Flex flexDirection='row' alignItems='center' gap='10px'>
+              <Switch
+                defaultChecked={user?.permSendEmail}
+                size='md'
+                colorScheme='teal'
+                onChange={() => setCheck(!check)}
+              />
+              <Text>{check ? '受け取る' : '受け取らない'}</Text>
+            </Flex>
+          </Box>
+        </VStack>
+        <Button width='100%' marginTop='4' colorScheme='teal' type='submit'>
+          更新する
+        </Button>
+      </form>
+    </Flex>
+  )
+}

--- a/src/common/utils/validate.ts
+++ b/src/common/utils/validate.ts
@@ -52,3 +52,11 @@ export const validateContactScreen = (args: {
   }
   return { isSuccess: true, message: '' }
 }
+
+// プロフィール更新画面のバリデーション
+export const validateUpdateProfileScreen = (username: string): Validate => {
+  if (!username) {
+    return { isSuccess: false, message: 'ユーザ名を入力してください' }
+  }
+  return { isSuccess: true, message: '' }
+}

--- a/src/lib/firebase/api/users.ts
+++ b/src/lib/firebase/api/users.ts
@@ -5,9 +5,11 @@ import {
   getDoc,
   getDocs,
   serverTimestamp,
+  updateDoc,
 } from 'firebase/firestore'
 
 import { AnswerResult } from '@/common/models/answer_result.model'
+import { FirebaseResult } from '@/common/models/firebase_result.model'
 import { User } from '@/common/models/user.model'
 import { auth, db } from '@/lib/config'
 
@@ -99,5 +101,41 @@ export const getAllAnswerResultFromUid = async (): Promise<AnswerResult[]> => {
       executedAt: date,
     })
   })
+  return result
+}
+
+/**
+ * ユーザ情報を更新する
+ * @param username
+ * @param permSendEmail
+ * @return Promise<FirebaseResult>
+ */
+export const updateUserInfo = async (args: {
+  username: string
+  permSendEmail: boolean
+}): Promise<FirebaseResult> => {
+  let result: FirebaseResult = {
+    isSuccess: false,
+    message: '',
+  }
+  const user = auth.currentUser
+  const docRef = doc(db, 'users', user!.uid)
+  try {
+    await updateDoc(docRef, {
+      username: args.username,
+      permSendEmail: args.permSendEmail,
+    }).then(() => {
+      result = {
+        isSuccess: true,
+        message: 'ユーザ情報を更新しました。',
+      }
+    })
+  } catch (error) {
+    result = {
+      isSuccess: false,
+      message: 'ユーザ情報の更新に失敗しました。',
+    }
+  }
+
   return result
 }


### PR DESCRIPTION
closed #68 について
## 対応内容
ユーザ情報の更新画面を実装
更新できる項目
- ユーザ名
- メール配信フラグ

上記対応に伴い、バリデーションとfirestore更新処理を追加