### PR TITLE
出題問題をランダムに出力する

### DIFF
--- a/src/common/utils/generate.ts
+++ b/src/common/utils/generate.ts
@@ -1,0 +1,28 @@
+/**
+ * 指定した範囲の乱数を重複無で生成する
+ * @param count 生成する乱数の個数
+ * @param min 最小値
+ * @param max 最大値
+ * @returns number[]
+ */
+export const generateUniqueRandomNumbers = (args: {
+  count: number
+  min: number
+  max: number
+}): number[] => {
+  if (args.count > args.max - args.min + 1) {
+    throw new Error(
+      'Cannot generate unique random numbers with the given range and count.'
+    )
+  }
+
+  const uniqueNumbers: Set<number> = new Set()
+
+  while (uniqueNumbers.size < args.count) {
+    const randomNumber =
+      Math.floor(Math.random() * (args.max - args.min + 1)) + args.min
+    uniqueNumbers.add(randomNumber)
+  }
+
+  return Array.from(uniqueNumbers)
+}

--- a/src/lib/firebase/api/questions.ts
+++ b/src/lib/firebase/api/questions.ts
@@ -1,6 +1,14 @@
-import { collection, getDocs, limit, query, where } from 'firebase/firestore'
+import {
+  collection,
+  getCountFromServer,
+  getDocs,
+  limit,
+  query,
+  where,
+} from 'firebase/firestore'
 
 import { Question } from '@/common/models/question.model'
+import { generateUniqueRandomNumbers } from '@/common/utils/generate'
 import { db } from '@/lib/config'
 
 /**
@@ -12,16 +20,30 @@ export const getQuestionsByExamTypeId = async (args: {
   examTypeId: string
   limit: number
 }): Promise<Question[]> => {
+  /** 選択した資格のdocumentIdを取得する */
   const colRef = collection(db, 'questions')
   const q = query(colRef, where('pltType', 'array-contains', args.examTypeId))
   const querySnapshot = await getDocs(q)
+  /** 取得したdocumentIdをもとに問題コレクションにアクセスする */
   const questionColRef = collection(
     db,
     'questions',
     querySnapshot.docs[0].id,
     args.examTypeId
   )
-  const questionQuery = query(questionColRef, limit(args.limit))
+  const countOfQuestions: number = await getCountFromServer(
+    questionColRef
+  ).then((snapshot) => snapshot.data().count)
+  const randomNumbers: number[] = generateUniqueRandomNumbers({
+    max: countOfQuestions,
+    min: 1,
+    count: args.limit,
+  })
+  const questionQuery = query(
+    questionColRef,
+    where('questionId', 'in', randomNumbers),
+    limit(args.limit)
+  )
   const questionQuerySnapshot = await getDocs(questionQuery)
   const questions: Question[] = questionQuerySnapshot.docs.map((doc) => {
     return {
@@ -32,5 +54,8 @@ export const getQuestionsByExamTypeId = async (args: {
       explanation: doc.data().explanation,
     }
   })
+  console.log(countOfQuestions)
+  console.log(randomNumbers)
+  console.log(questions)
   return questions
 }


### PR DESCRIPTION
closed #54 について
## 実装内容
最小値、最大値、生成数を指定して、ランダム数の配列を生成する共通処理を実装
生成されたランダム数の配列をもとに、firestoreから問題を取得し、出題するように実装